### PR TITLE
:bulb: feat(head): Incluir Swiper e fontes do Google Fonts no head

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,16 @@
     <link rel="icon" type="image/svg" sizes="16x16" href="./src/assets/svg/icone.svg">
     <link rel="stylesheet" href="./src/styles/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap" rel="stylesheet">
 
+
+
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"
+/>
 </head>
 
 <body>


### PR DESCRIPTION
Adição dos links do Swiper.js e das fontes externas via Google Fonts na tag <head>, preparando o ambiente para carrosséis e estilização tipográfica.